### PR TITLE
add I2C Slave library

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -7273,3 +7273,4 @@ https://github.com/sierramike/HomeAssistantMQTT
 https://github.com/DannyRavi/AD7747
 https://github.com/avandalen/avdweb_CodeDebugScope
 https://github.com/LeeLeahy2/R4A_ESP32
+https://github.com/yuri-rage/arduino-i2c-slave


### PR DESCRIPTION
Library to create a simple I2C device, primarily intended for communication with ArduPilot-based autopilots, but can be used in any application where a discrete, custom I2C device is desired.